### PR TITLE
refactor(youtube): replace API with web scraping

### DIFF
--- a/lua/mediaplayer/services/youtube/init.lua
+++ b/lua/mediaplayer/services/youtube/init.lua
@@ -141,6 +141,12 @@ function SERVICE:GetMetadata( callback )
 		self:Fetch( videoUrl,
 			function( body, length, headers, code )
 				local metadata = self:ParseYTMetaDataFromHTML(body, videoId)
+				
+				--html couldn't be parsed
+				if (!metadata.title || !metadata.duration) then
+					callback(false, "Failed to parse HTML Page for metadata")
+					return
+				end
 
 				self:SetMetadata(metadata, true)
 

--- a/lua/mediaplayer/services/youtube/init.lua
+++ b/lua/mediaplayer/services/youtube/init.lua
@@ -201,7 +201,7 @@ function SERVICE:ParseYTMetaDataFromHTML( html, videoId )
     -- Lua search patterns to find metadata from the html
     local patterns = {
         ["title"] = "<meta%sproperty=\"og:title\"%s-content=%b\"\">",
-        ["titlepat_fallback"] = "<title>.-</title>",
+        ["title_fallback"] = "<title>.-</title>",
         ["thumb"] = "<meta%sproperty=\"og:image\"%s-content=%b\"\">",
         ["thumb_fallback"] = "<link%sitemprop=\"thumbnailUrl\"%s-href=%b\"\">",
         ["duration"] = "<meta%sitemprop%s-=%s-\"duration\"%s-content%s-=%s-%b\"\">",

--- a/lua/mediaplayer/services/youtube/init.lua
+++ b/lua/mediaplayer/services/youtube/init.lua
@@ -3,10 +3,6 @@ include "shared.lua"
 
 local TableLookup = MediaPlayerUtils.TableLookup
 
--- https://developers.google.com/youtube/v3/
-local APIKey = MediaPlayer.GetConfigValue('google.api_key')
-local MetadataUrl = "https://www.googleapis.com/youtube/v3/videos?id=%s&key=%s&type=video&part=contentDetails,snippet,status&videoEmbeddable=true&videoSyndicated=true"
-
 ---
 -- Helper function for converting ISO 8601 time strings; this is the formatting
 -- used for duration specified in the YouTube v3 API.
@@ -106,7 +102,7 @@ function SERVICE:GetMetadata( callback )
 				if self:IsTimed() then
 					MediaPlayer.Metadata:Save(self)
 				end
-			
+
 				callback(self._metadata)
 			end,
 			-- On failure
@@ -123,7 +119,7 @@ end
 
 ---
 -- Get the value for an attribute from a html element
--- 
+--
 local function ParseElementAttribute( element, attribute )
 	if not element then return end
 	-- Find the desired attribute
@@ -172,19 +168,19 @@ function SERVICE:ParseYTMetaDataFromHTML( html )
 	-- Parse HTML entities in the title into symbols
 	metadata.title = url.htmlentities_decode(metadata.title)
 
-	metadata.thumbnail = ParseElementAttribute(string.match(html, patterns["thumb"]), "content") 
+	metadata.thumbnail = ParseElementAttribute(string.match(html, patterns["thumb"]), "content")
 		or ParseElementAttribute(string.match(html, patterns["thumb_fallback"]), "href")
 
 	-- See if the video is an ongoing live broadcast
 	-- Set duration to 0 if it is, otherwise use the actual duration
 	local isLiveBroadcast = tobool(ParseElementAttribute(string.match(html, patterns["live"]), "content"))
 	local broadcastEndDate = string.match(html, patterns["live_enddate"])
-	if isLiveBroadcast and not broadcastEndDate then 
+	if isLiveBroadcast and not broadcastEndDate then
 		-- Mark as live video
 		metadata.duration = 0
-	else 
+	else
 		local durationISO8601 = ParseElementAttribute(string.match(html, patterns["duration"]), "content")
-		if isstring(durationISO8601) then 
+		if isstring(durationISO8601) then
 			metadata.duration = math.max(1, convertISO8601Time(durationISO8601))
 		end
 	end


### PR DESCRIPTION
Hello, I updated the GetMetadata function to get meta data info from the parsed HTML page instead. The new function "ParseYTMetaDataFromHTML" takes care of this. The video requests can be a bit slow, since it requests an almost 1MB web page, maybe there is a better way to do this, I also have no idea how stable of a fix this will be, if youtube changes the names of the variables in future, it will no longer work.


```
---
-- Function to parse video metadata straight from the html instead of using the API
--
function SERVICE:ParseYTMetaDataFromHTML( html, videoId )
	--Lua search patterns to find Title and Duration from the html mess
	local titlepat = "\\\"title\\\":\\\".-\\\""
	local durationpat = "\\\"lengthSeconds\\\":\\\".-\\\""

	--MetaData table to return when we're done
	local metadata = {}

	--Find Title & Duration from the html and parse them, then insert to the table
	for parseTitle in string.gmatch(html, titlepat) do
		metadata.title = string.sub(parseTitle, 13, -3)
		break
	end

	for parseDuration in string.gmatch(html, durationpat) do
		metadata.duration = tonumber(string.sub(parseDuration, 21, -3))
		break
	end

	--Thumbnail can simply be retrieved with an URL, no need for parsing
	parsedThumb = "https://i.ytimg.com/vi/"..videoId.."/maxresdefault.jpg"
	metadata.thumbnail = parsedThumb

	return metadata
end
```

fixes #33