### PR TITLE
Fix Mediaplayer errors and url bar

### DIFF
--- a/lua/autorun/mediaplayer.lua
+++ b/lua/autorun/mediaplayer.lua
@@ -1,3 +1,5 @@
+resource.AddWorkshop( "546392647" ) -- Media Player workshop
+
 local basepath = "mediaplayer/"
 
 local function IncludeMP( filepath )

--- a/lua/autorun/mediaplayer.lua
+++ b/lua/autorun/mediaplayer.lua
@@ -1,5 +1,3 @@
-resource.AddWorkshop( "546392647" ) -- Media Player workshop
-
 local basepath = "mediaplayer/"
 
 local function IncludeMP( filepath )
@@ -55,6 +53,9 @@ local function LoadMediaPlayer()
 	IncludeCS "includes/modules/EventEmitter.lua"
 
 	if SERVER then
+		-- Add mediaplayer models
+		resource.AddWorkshop( "546392647" )
+
 		-- download clientside includes
 		AddCSLuaFile "includes/modules/browserpool.lua"
 		AddCSLuaFile "includes/modules/inputhook.lua"

--- a/lua/mediaplayer/controls/dmediaplayerhtml.lua
+++ b/lua/mediaplayer/controls/dmediaplayerhtml.lua
@@ -111,8 +111,11 @@ function PANEL:Think()
 end
 
 function PANEL:FetchPageURL()
-	local js = "gmod.getUrl(window.location.href);"
-	self:RunJavascript(js)
+	self:AddFunction( "gmod", "getUrl", function( geturl )
+		self:SetURL( geturl )
+	end )
+
+	self:RunJavascript( [[gmod.getUrl(window.location.href);]] )
 end
 
 function PANEL:GetURL()
@@ -479,6 +482,22 @@ function PANEL:MoveToCursor( xoffset, yoffset )
 
 	local cx, cy = input.GetCursorPos()
 	self:SetPos( cx - xoffset, cy - yoffset )
+end
+
+-- Youtube specific fix
+function PANEL:OnDocumentReady( url )
+	if url ~= "https://www.youtube.com/" then return end
+	self:AddFunction( "gmod", "getUrl", function( geturl )
+		self:SetURL( geturl )
+	end )
+
+	self:QueueJavascript( [[
+		function run(){
+			if (typeof gmod == "undefined") { return };
+			gmod.getUrl(window.location.href);
+		};
+		window.addEventListener( 'yt-navigate-start', run, true )
+	]] )
 end
 
 derma.DefineControl( "DMediaPlayerHTML", "", PANEL, "Awesomium" )

--- a/lua/mediaplayer/controls/dmediaplayerhtml.lua
+++ b/lua/mediaplayer/controls/dmediaplayerhtml.lua
@@ -42,16 +42,6 @@ function PANEL:Init()
 	--
 	-- Implement a console - because awesomium doesn't provide it for us anymore
 	--
-	local console_funcs = {'log','error','debug','warn','info'}
-	for _, func in pairs(console_funcs) do
-		self:AddFunction( "console", func, function(param)
-			self:ConsoleMessage( param, func )
-		end )
-	end
-
-	self:AddFunction( "gmod", "getUrl", function( url )
-		self:SetURL( url )
-	end )
 
 	hook.Add( "HUDPaint", self, function() self:HUDPaint() end )
 
@@ -111,10 +101,6 @@ function PANEL:Think()
 end
 
 function PANEL:FetchPageURL()
-	self:AddFunction( "gmod", "getUrl", function( geturl )
-		self:SetURL( geturl )
-	end )
-
 	self:RunJavascript( [[gmod.getUrl(window.location.href);]] )
 end
 
@@ -484,20 +470,33 @@ function PANEL:MoveToCursor( xoffset, yoffset )
 	self:SetPos( cx - xoffset, cy - yoffset )
 end
 
--- Youtube specific fix
 function PANEL:OnDocumentReady( url )
-	if url ~= "https://www.youtube.com/" then return end
-	self:AddFunction( "gmod", "getUrl", function( geturl )
-		self:SetURL( geturl )
+	local console_funcs = {'log','error','debug','warn','info'}
+	for _, func in pairs(console_funcs) do
+		self:AddFunction( "console", func, function(param)
+			self:ConsoleMessage( param, func )
+		end )
+	end
+
+	self:AddFunction( "gmod", "getUrl", function( url )
+		self:SetURL( url )
 	end )
 
-	self:QueueJavascript( [[
-		function run(){
-			if (typeof gmod == "undefined") { return };
-			gmod.getUrl(window.location.href);
-		};
-		window.addEventListener( 'yt-navigate-start', run, true )
-	]] )
+
+	-- Youtube specific fix because youtube uses clientside routing which doesn't trigger OnDocumentReady and such events
+	if url == "https://www.youtube.com/" then
+		self:AddFunction( "gmod", "getUrl", function( geturl )
+			self:SetURL( geturl )
+		end )
+
+		self:QueueJavascript( [[
+			function run(){
+				if (typeof gmod == "undefined") { return };
+				gmod.getUrl(window.location.href);
+			};
+			window.addEventListener( 'yt-navigate-start', run, true )
+		]] )
+	end
 end
 
 derma.DefineControl( "DMediaPlayerHTML", "", PANEL, "Awesomium" )

--- a/lua/mediaplayer/services/base/init.lua
+++ b/lua/mediaplayer/services/base/init.lua
@@ -26,7 +26,7 @@ end
 
 local HttpHeaders = {
 	["Cache-Control"] = "no-cache",
-	["Connection"] = "keep-alive",
+	--["Connection"] = "keep-alive",
 
 	-- Required for Google API requests; uses browser API key.
 	["Referer"] = MediaPlayer.GetConfigValue('google.referrer'),

--- a/lua/mediaplayer/sh_metadata.lua
+++ b/lua/mediaplayer/sh_metadata.lua
@@ -146,7 +146,7 @@ function MediaPlayer.Metadata:Save( media )
 			string.format( "%s,", sql.SQLStr( media:Title() ) ) ..
 			string.format( "%s,", media:Duration() ) ..
 			string.format( "%s,", sql.SQLStr( media:Thumbnail() ) ) ..
-			string.format( "%s,", sql.SQLStr( util.TableToJSON(media._metadata.extra) ) ) ..
+			string.format( "%s,", sql.SQLStr( util.TableToJSON(media._metadata.extra or {}) ) ) ..
 			string.format( "%d,", os.time() ) ..
 			string.format( "%d)", os.time() )
 

--- a/lua/mediaplayer/sh_metadata.lua
+++ b/lua/mediaplayer/sh_metadata.lua
@@ -107,6 +107,8 @@ function MediaPlayer.Metadata:Save( media )
 	local query = ("SELECT expired FROM `%s` WHERE id='%s'"):format(TableName, id)
 	local results = sql.Query(query)
 
+	media._metadata.extra = media._metadata.extra or {}
+
 	if istable(results) then -- update
 
 		if MediaPlayer.DEBUG then
@@ -146,7 +148,7 @@ function MediaPlayer.Metadata:Save( media )
 			string.format( "%s,", sql.SQLStr( media:Title() ) ) ..
 			string.format( "%s,", media:Duration() ) ..
 			string.format( "%s,", sql.SQLStr( media:Thumbnail() ) ) ..
-			string.format( "%s,", sql.SQLStr( util.TableToJSON(media._metadata.extra or {}) ) ) ..
+			string.format( "%s,", sql.SQLStr( util.TableToJSON(media._metadata.extra) ) ) ..
 			string.format( "%d,", os.time() ) ..
 			string.format( "%d)", os.time() )
 


### PR DESCRIPTION
This PR fixes the follow issues present in mediaplayer:

- Javascript errors because `gmod.getUrl` isn't present anymore.
- The navbar url not updating due to youtube's new navigation method.
- Fixes an issue where `keep-alive` causes `unsuccessful` on dedicated servers.
- Fixed an error that can occur when extra meta data failes to properly load.
- Added automatic workshop.Add addition.