### PR TITLE
Avoid calling of `DrawMediaPlayerOff` in Resolved Depth Pass

### DIFF
--- a/lua/entities/mediaplayer_tv/shared.lua
+++ b/lua/entities/mediaplayer_tv/shared.lua
@@ -58,7 +58,7 @@ else -- CLIENT
 	local TextScale = 700
 
 	function ENT:Draw(flags)
-		self:DrawModel()
+		self:DrawModel(flags)
 
 		local isDepthPass = ( bit.band( flags, STUDIO_SSAODEPTHTEXTURE ) != 0 || bit.band( flags, STUDIO_SHADOWDEPTHTEXTURE ) != 0 )
 		if ( isDepthPass ) then return end

--- a/lua/entities/mediaplayer_tv/shared.lua
+++ b/lua/entities/mediaplayer_tv/shared.lua
@@ -57,8 +57,11 @@ else -- CLIENT
 	local StaticMaterial = Material( "theater/STATIC" )
 	local TextScale = 700
 
-	function ENT:Draw()
+	function ENT:Draw(flags)
 		self:DrawModel()
+
+		local isDepthPass = ( bit.band( flags, STUDIO_SSAODEPTHTEXTURE ) != 0 || bit.band( flags, STUDIO_SHADOWDEPTHTEXTURE ) != 0 )
+		if ( isDepthPass ) then return end
 
 		local mp = self:GetMediaPlayer()
 


### PR DESCRIPTION
Avoid to call `DrawMediaPlayerOff` in Resolved Depth Pass.

Pull request result (fixed color writing to depth, see Normals render target on left):
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f452721c-690d-4758-aa86-59cb807b43f1" />

Fixed bug (colors .RGB writes to depth, noise on normals on screen):
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/e451c44f-89d2-4295-98d0-8ddc9db2e60a" />

Some info about resolved depth pass from Gmod:
https://wiki.facepunch.com/gmod/render.GetResolvedFullFrameDepth
https://wiki.facepunch.com/gmod/GM:NeedsDepthPass
